### PR TITLE
Update getting-started.md

### DIFF
--- a/ci-cd/reference-implementation/gitlab/getting-started.md
+++ b/ci-cd/reference-implementation/gitlab/getting-started.md
@@ -311,14 +311,12 @@ The root directory should contain a **.gitlab-ci.yml**, **.gitignore**, **.force
 {% tabs %}
 {% tab title="CP" %}
 ```bash
-cd dxatscale-template
 cp -vR dxatscale-template dxatscale-poc
 ```
 {% endtab %}
 
 {% tab title="RSYNC" %}
 ```text
-cd dxatscale-template
 rsync -av dxatscale-template dxatscale-poc
 ```
 {% endtab %}

--- a/ci-cd/reference-implementation/gitlab/getting-started.md
+++ b/ci-cd/reference-implementation/gitlab/getting-started.md
@@ -311,13 +311,13 @@ The root directory should contain a **.gitlab-ci.yml**, **.gitignore**, **.force
 {% tabs %}
 {% tab title="CP" %}
 ```bash
-cp -vR dxatscale-template dxatscale-poc
+cp -vR dxatscale-template/* dxatscale-poc
 ```
 {% endtab %}
 
 {% tab title="RSYNC" %}
 ```text
-rsync -av dxatscale-template dxatscale-poc
+rsync -av dxatscale-template/* dxatscale-poc
 ```
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
if you specify folder name when copying you do not need to cd into it, otherwise you get error