### PR TITLE
Update publish-and-fetch-your-artifacts.md

### DIFF
--- a/challenges/challenges/publish-and-fetch-your-artifacts.md
+++ b/challenges/challenges/publish-and-fetch-your-artifacts.md
@@ -75,6 +75,7 @@ sfdx sfpowerscripts:orchestrator:release --help
 ![Token expiration field](https://docs.github.com/assets/images/help/settings/token\_expiration.png)
 
 * Select the scopes, or permissions, you'd like to grant this token. To use your token to access repositories from the command line, select **repo**.
+* Github has updated their token options, you need to check the "read and write packages" to be able to use it.
 
 ![Selecting token scopes](https://docs.github.com/assets/images/help/settings/token\_scopes.gif)
 


### PR DESCRIPTION
Updated the MD file with new github options for token, other wise the script don't prompt the error and it just says: `Command failed: npm publish --tag origin` 
I've debugged the sfpowerscripts:orchestrator:publish to understand how the project was using the npm to get the real error. Then used npm commands to get this message: `401 Unauthorized - PUT https://npm.pkg.github.com/@rodrigodantas%2fdreamhouse-app_sfpowerscripts_artifact - Your token has not been granted the required scopes to execute this query. The 'id' field requires one of the following scopes: ['read:packages'], but your token has only been granted the: ['delete_repo', 'read:repo_hook', 'repo'] scopes. Please modify your token's scopes at: https://github.com/settings/tokens.
<img width="813" alt="Screen Shot 2022-06-22 at 16 17 42 PM" src="https://user-images.githubusercontent.com/6199557/175052451-4ca44c4d-948c-4aa1-a29a-676419612ae8.png">
<img width="1170" alt="Screen Shot 2022-06-22 at 16 18 20 PM" src="https://user-images.githubusercontent.com/6199557/175052496-a79994fb-e7fa-4046-9a77-545011e677a7.png">
`