### PR TITLE
remove link to github discussions

### DIFF
--- a/about-us/contact-us.md
+++ b/about-us/contact-us.md
@@ -20,10 +20,6 @@ Want to ask more of any of these practices, ask the team directly on Slack, Clic
 
 {% embed url="https://launchpass.com/dxatscale" %}
 
-For discussions on the tools visit the DX@Scale GitHub discussion pages.
-
-{% embed url="https://github.com/orgs/dxatscale/discussions" %}
-
 ## YouTube
 
 {% embed url="https://www.youtube.com/channel/UCZ4I3Llb9wmEjFAOfjufLNQ" %}


### PR DESCRIPTION
Github discussions is not used anymore on the project.